### PR TITLE
Topic onboarding adjustments

### DIFF
--- a/Features/Suggestions/Services/SuggestionYouTubeService.cs
+++ b/Features/Suggestions/Services/SuggestionYouTubeService.cs
@@ -38,7 +38,7 @@ public class SuggestionYouTubeService : ISuggestionYouTubeService
     public async Task<YouTubeApiResult<List<VideoInfo>>> SearchVideosByTopicAsync(
         string topicQuery, DateTime? publishedAfter = null, int maxResults = 50)
     {
-        return await _sharedYouTubeService.SearchVideosByTopicAsync(topicQuery, publishedAfter, maxResults);
+        return await _sharedYouTubeService.SearchVideosByTopicAsync(topicQuery, publishedAfter);
     }
 
     /// <summary>
@@ -132,7 +132,7 @@ public class SuggestionYouTubeService : ISuggestionYouTubeService
 
         foreach (var topic in validTopics)
         {
-            var result = await _sharedYouTubeService.SearchVideosByTopicAsync(topic, publishedAfter, maxResultsPerTopic);
+            var result = await _sharedYouTubeService.SearchVideosByTopicAsync(topic, publishedAfter);
 
             if (result.IsSuccess)
             {

--- a/Features/TopicVideos/Services/TopicVideosService.cs
+++ b/Features/TopicVideos/Services/TopicVideosService.cs
@@ -81,10 +81,7 @@ public class TopicVideosService : ITopicVideosService
             var publishedAfter = DateTime.UtcNow.AddYears(-LOOKBACK_YEARS);
 
             // Search YouTube using the shared service
-            var youTubeResult = await _youTubeService.SearchVideosByTopicAsync(
-                topicName,
-                publishedAfter,
-                maxResults);
+            var youTubeResult = await _youTubeService.SearchVideosByTopicAsync(topicName, publishedAfter);
 
             if (!youTubeResult.IsSuccess)
             {

--- a/Services/Interfaces/ISharedYouTubeService.cs
+++ b/Services/Interfaces/ISharedYouTubeService.cs
@@ -30,10 +30,7 @@ public interface ISharedYouTubeService
     /// <param name="publishedAfter">Only include videos published after this date (optional)</param>
     /// <param name="maxResults">Maximum number of videos to return (1-100)</param>
     /// <returns>API result containing list of videos or error information</returns>
-    Task<YouTubeApiResult<List<VideoInfo>>> SearchVideosByTopicAsync(
-        string topicQuery,
-        DateTime? publishedAfter = null,
-        int maxResults = 100);
+    Task<YouTubeApiResult<List<VideoInfo>>> SearchVideosByTopicAsync(string topicQuery, DateTime? publishedAfter = null);
 
     /// <summary>
     /// Gets detailed information about multiple videos by their YouTube IDs.


### PR DESCRIPTION
Removed initial max settings so we always pull 100 videos. Changed Topic Onboarding so we pull in all videos with a relevance score 5 or above.